### PR TITLE
Add refined model pipeline and Streamlit prediction app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+models/
+results/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -69,3 +69,30 @@ app.py
 requirements.txt
 
 
+
+
+## Refined Model Pipeline
+
+Train the latest gradient boosting model and store its artifacts:
+
+```bash
+python main.py \
+  --train-data youtube_channels_with_features.csv \
+  --model-out models/refined_subscriber_model.joblib \
+  --metrics-out results/metrics.json
+```
+
+The script prints evaluation metrics to the console and writes them to
+`results/metrics.json`. The serialized model powers the Streamlit app described
+below.
+
+## Interactive Web App
+
+Once the model artifact exists, launch the Streamlit experience:
+
+```bash
+streamlit run app.py
+```
+
+Use the sidebar to enter a channel's metrics (views, uploads, age). You can also
+upload a CSV with the required feature columns to generate batch predictions.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,161 @@
+"""Streamlit app for predicting YouTube channel subscribers."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+MODEL_PATH = Path("models/refined_subscriber_model.joblib")
+FEATURE_COLUMNS = ["views", "videos", "channel_age_years", "views_per_video"]
+
+
+def load_model(path: Path = MODEL_PATH):
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Model artifact not found at {path}. Run `python main.py` to train and save the model first."
+        )
+    return joblib.load(path)
+
+
+@st.cache_resource
+def get_model():
+    return load_model()
+
+
+def make_single_prediction(model, features: dict) -> float:
+    data = pd.DataFrame([features], columns=FEATURE_COLUMNS)
+    prediction = model.predict(data)[0]
+    return float(np.clip(prediction, a_min=0, a_max=None))
+
+
+def predict_from_dataframe(model, df: pd.DataFrame) -> pd.DataFrame:
+    required = set(FEATURE_COLUMNS)
+    if not required.issubset(df.columns):
+        missing = required - set(df.columns)
+        raise ValueError(
+            "Uploaded file is missing required columns: " + ", ".join(sorted(missing))
+        )
+    predictions = model.predict(df[FEATURE_COLUMNS])
+    df = df.copy()
+    df["predicted_subs"] = np.clip(predictions, a_min=0, a_max=None)
+    return df
+
+
+def sidebar_inputs() -> dict:
+    st.sidebar.header("Channel metrics")
+
+    views = st.sidebar.number_input(
+        "Total channel views",
+        min_value=0.0,
+        value=5_000_000.0,
+        step=100_000.0,
+        help="Total lifetime views across all channel videos.",
+    )
+    videos = st.sidebar.number_input(
+        "Number of uploaded videos",
+        min_value=1.0,
+        value=250.0,
+        step=1.0,
+        help="Published videos on the channel.",
+    )
+    age_years = st.sidebar.number_input(
+        "Channel age (years)",
+        min_value=0.1,
+        value=6.0,
+        step=0.1,
+        help="Age of the channel in years.",
+    )
+
+    views_per_video = views / videos if videos else 0.0
+
+    st.sidebar.caption(
+        "`views_per_video` is derived automatically as views divided by videos."
+    )
+
+    return {
+        "views": views,
+        "videos": videos,
+        "channel_age_years": age_years,
+        "views_per_video": views_per_video,
+    }
+
+
+def render_single_prediction(model) -> None:
+    st.subheader("Estimate subscribers for a single channel")
+    features = sidebar_inputs()
+
+    if st.button("Predict subscribers", type="primary"):
+        prediction = make_single_prediction(model, features)
+        st.metric(
+            "Predicted subscribers",
+            f"{prediction:,.0f}",
+            help="Estimated subscriber count using the refined gradient boosting model.",
+        )
+
+        st.write("### Model inputs")
+        st.write(pd.DataFrame([features]))
+
+
+def render_batch_prediction(model) -> None:
+    st.subheader("Batch predictions from CSV")
+    st.write(
+        "Upload a CSV file with the columns `views`, `videos`, `channel_age_years`, "
+        "and `views_per_video` to score multiple channels at once."
+    )
+
+    uploaded_file = st.file_uploader("Upload CSV", type=["csv"])
+    if uploaded_file is not None:
+        try:
+            df = pd.read_csv(uploaded_file)
+            predictions = predict_from_dataframe(model, df)
+        except Exception as exc:  # pylint: disable=broad-except
+            st.error(f"Could not generate predictions: {exc}")
+        else:
+            st.success("Predictions generated successfully")
+            st.dataframe(predictions.head(20))
+
+            csv_bytes = predictions.to_csv(index=False).encode("utf-8")
+            st.download_button(
+                "Download predictions",
+                data=csv_bytes,
+                file_name="youtube_subscriber_predictions.csv",
+                mime="text/csv",
+            )
+
+
+def main() -> None:
+    st.set_page_config(
+        page_title="YouTube Subscriber Predictor",
+        page_icon="📈",
+        layout="wide",
+    )
+    st.title("YouTube Subscriber Predictor")
+    st.write(
+        "This app uses a refined gradient boosting model trained on channel-level "
+        "engagement metrics to estimate subscriber counts. Provide your channel's "
+        "statistics or upload a CSV to get predictions."
+    )
+
+    try:
+        model = get_model()
+    except FileNotFoundError as exc:
+        st.error(str(exc))
+        st.stop()
+
+    with st.expander("Model details", expanded=False):
+        st.write(
+            "The model is a `HistGradientBoostingRegressor` wrapped in a transformed "
+            "target pipeline to model `log1p(subscribers)`. It uses normalized `views`, "
+            "`videos`, `channel_age_years`, and `views_per_video` as predictors."
+        )
+
+    render_single_prediction(model)
+    st.divider()
+    render_batch_prediction(model)
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,257 @@
+"""Train the refined YouTube subscriber prediction model.
+
+This script loads the engineered channel-level features, trains a
+HistGradientBoostingRegressor wrapped in a TransformedTargetRegressor (to model
+``log1p(subs)``), evaluates the model, and persists the trained artifact along
+with evaluation metrics.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.impute import SimpleImputer
+from sklearn.metrics import mean_squared_error, mean_squared_log_error, r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import FunctionTransformer, StandardScaler
+from sklearn.compose import TransformedTargetRegressor
+
+
+DEFAULT_DATA_PATH = Path("youtube_channels_with_features.csv")
+DEFAULT_MODEL_PATH = Path("models/refined_subscriber_model.joblib")
+DEFAULT_METRICS_PATH = Path("results/metrics.json")
+
+FEATURE_COLUMNS: List[str] = [
+    "views",
+    "videos",
+    "channel_age_years",
+    "views_per_video",
+]
+TARGET_COLUMN = "subs"
+
+
+@dataclass
+class TrainingArtifacts:
+    """Container for trained objects and metadata."""
+
+    model: TransformedTargetRegressor
+    metrics: Dict[str, float]
+    feature_columns: List[str]
+
+
+def _log1p_array(x: np.ndarray) -> np.ndarray:
+    """Apply ``log1p`` element-wise while preserving array shape."""
+
+    return np.log1p(np.clip(x, a_min=0, a_max=None))
+
+
+def _inverse_log1p_array(x: np.ndarray) -> np.ndarray:
+    """Apply inverse ``log1p`` (``expm1``) element-wise."""
+
+    return np.expm1(x)
+
+
+def build_preprocessor() -> ColumnTransformer:
+    """Create the preprocessing pipeline used across training and inference."""
+
+    log_features = ["views", "videos", "views_per_video"]
+    linear_features = ["channel_age_years"]
+
+    log_pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="median")),
+            (
+                "log",
+                FunctionTransformer(
+                    _log1p_array,
+                    feature_names_out="one-to-one",
+                ),
+            ),
+            ("scaler", StandardScaler()),
+        ]
+    )
+
+    linear_pipeline = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", StandardScaler()),
+        ]
+    )
+
+    preprocessor = ColumnTransformer(
+        transformers=[
+            ("log", log_pipeline, log_features),
+            ("linear", linear_pipeline, linear_features),
+        ]
+    )
+
+    return preprocessor
+
+
+def build_model(random_state: int = 42) -> TransformedTargetRegressor:
+    """Create the full modeling pipeline wrapped with log-target transformation."""
+
+    regressor = Pipeline(
+        steps=[
+            ("preprocessor", build_preprocessor()),
+            (
+                "regressor",
+                HistGradientBoostingRegressor(
+                    loss="squared_error",
+                    max_depth=8,
+                    max_iter=500,
+                    learning_rate=0.05,
+                    l2_regularization=0.01,
+                    min_samples_leaf=20,
+                    random_state=random_state,
+                ),
+            ),
+        ]
+    )
+
+    model = TransformedTargetRegressor(
+        regressor=regressor,
+        func=_log1p_array,
+        inverse_func=_inverse_log1p_array,
+        check_inverse=False,
+    )
+
+    return model
+
+
+def load_dataset(path: Path) -> pd.DataFrame:
+    """Load the feature dataset and validate required columns."""
+
+    df = pd.read_csv(path)
+
+    missing_cols = [col for col in FEATURE_COLUMNS + [TARGET_COLUMN] if col not in df.columns]
+    if missing_cols:
+        raise ValueError(
+            f"The dataset at {path} is missing required columns: {', '.join(missing_cols)}"
+        )
+
+    return df
+
+
+def evaluate_model(
+    model: TransformedTargetRegressor,
+    X_test: pd.DataFrame,
+    y_test: pd.Series,
+) -> Dict[str, float]:
+    """Compute evaluation metrics on the holdout set."""
+
+    y_pred = np.clip(model.predict(X_test), a_min=0, a_max=None)
+
+    log_true = np.log1p(y_test)
+    log_pred = np.log1p(y_pred)
+
+    metrics = {
+        "r2_log": float(r2_score(log_true, log_pred)),
+        "rmsle": float(np.sqrt(mean_squared_log_error(y_test, y_pred))),
+        "rmse": float(mean_squared_error(y_test, y_pred, squared=False)),
+        "mae": float(np.mean(np.abs(y_test - y_pred))),
+    }
+
+    return metrics
+
+
+def train_model(
+    df: pd.DataFrame,
+    test_size: float = 0.2,
+    random_state: int = 42,
+) -> TrainingArtifacts:
+    """Train the refined model and compute evaluation metrics."""
+
+    X = df[FEATURE_COLUMNS]
+    y = df[TARGET_COLUMN]
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state
+    )
+
+    model = build_model(random_state=random_state)
+    model.fit(X_train, y_train)
+
+    metrics = evaluate_model(model, X_test, y_test)
+
+    return TrainingArtifacts(model=model, metrics=metrics, feature_columns=FEATURE_COLUMNS)
+
+
+def save_model(model: TransformedTargetRegressor, path: Path) -> None:
+    """Persist the trained model pipeline to disk."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, path)
+
+
+def save_metrics(metrics: Dict[str, float], path: Path) -> None:
+    """Persist evaluation metrics as JSON."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train the refined subscriber model")
+    parser.add_argument(
+        "--train-data",
+        type=Path,
+        default=DEFAULT_DATA_PATH,
+        help="Path to the CSV file containing engineered channel features.",
+    )
+    parser.add_argument(
+        "--model-out",
+        type=Path,
+        default=DEFAULT_MODEL_PATH,
+        help="Where to save the trained model artifact (joblib).",
+    )
+    parser.add_argument(
+        "--metrics-out",
+        type=Path,
+        default=DEFAULT_METRICS_PATH,
+        help="Where to save the evaluation metrics JSON file.",
+    )
+    parser.add_argument(
+        "--test-size",
+        type=float,
+        default=0.2,
+        help="Fraction of the dataset to allocate to the test split.",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=42,
+        help="Random seed for data splitting and model reproducibility.",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> Tuple[TransformedTargetRegressor, Dict[str, float]]:
+    args = parse_args()
+
+    df = load_dataset(args.train_data)
+    artifacts = train_model(df, test_size=args.test_size, random_state=args.random_state)
+
+    save_model(artifacts.model, args.model_out)
+    save_metrics(artifacts.metrics, args.metrics_out)
+
+    print("Training complete. Metrics:")
+    for key, value in artifacts.metrics.items():
+        print(f"  {key}: {value:.4f}")
+
+    return artifacts.model, artifacts.metrics
+
+
+if __name__ == "__main__":
+    main()

--- a/refined_model.py
+++ b/refined_model.py
@@ -1,0 +1,193 @@
+"""Refined YouTube subscriber prediction model.
+
+This script trains an improved regression model using gradient boosting and
+additional feature engineering compared to the baseline notebook.  It prints
+cross-validation metrics and hold-out performance along with the top features
+(by split gain) for transparency.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.impute import SimpleImputer
+from sklearn.metrics import make_scorer, mean_squared_log_error, r2_score
+from sklearn.model_selection import cross_validate, train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import FunctionTransformer, StandardScaler
+from sklearn.utils.validation import check_is_fitted
+from sklearn.compose import TransformedTargetRegressor
+
+DATA_CANDIDATES = [
+    Path("YouTube_Combined_Cleaned (1).csv"),
+    Path("youtube_channels_with_features.csv"),
+    Path("sample_youtube_channels.csv"),
+]
+
+
+def _load_dataset() -> pd.DataFrame:
+    for path in DATA_CANDIDATES:
+        if path.exists():
+            df = pd.read_csv(path)
+            print(f"Loaded dataset: {path} ({len(df):,} rows)")
+            return df
+    raise FileNotFoundError(
+        "Could not find any of the expected datasets: "
+        + ", ".join(str(p) for p in DATA_CANDIDATES)
+    )
+
+
+def _engineer_features(raw: pd.DataFrame) -> pd.DataFrame:
+    df = raw.copy()
+    df['published'] = pd.to_datetime(df['published'], errors='coerce', utc=True)
+    df = df.dropna(subset=['published', 'views', 'videos', 'subs']).copy()
+
+    now = pd.Timestamp.utcnow()
+    df['channel_age_years'] = (now - df['published']).dt.days / 365.25
+
+    # Derived, leakage-safe features.
+    df['views_per_video'] = np.where(df['videos'] > 0, df['views'] / df['videos'], np.nan)
+    df['uploads_per_year'] = np.where(df['channel_age_years'] > 0,
+                                      df['videos'] / df['channel_age_years'],
+                                      np.nan)
+    df['log_views_growth'] = np.log1p(df['views']) / np.maximum(df['channel_age_years'], 0.1)
+
+    df = df.replace([np.inf, -np.inf], np.nan)
+    return df
+
+
+def _build_pipeline(numeric_features: list[str]) -> Pipeline:
+    log_transformer = FunctionTransformer(lambda x: np.log1p(np.clip(x, a_min=0, a_max=None)),
+                                          validate=False)
+
+    numeric_pipeline = Pipeline(steps=[
+        ("impute", SimpleImputer(strategy="median")),
+        ("log", log_transformer),
+        ("scale", StandardScaler()),
+    ])
+
+    preprocessor = ColumnTransformer(
+        transformers=[
+            ("num", numeric_pipeline, numeric_features),
+        ],
+        remainder="drop",
+    )
+
+    gbr_params = dict(
+        learning_rate=0.06,
+        max_depth=None,
+        max_leaf_nodes=63,
+        min_samples_leaf=25,
+        l2_regularization=0.15,
+        random_state=42,
+    )
+
+    gb_regressor = HistGradientBoostingRegressor(**gbr_params)
+
+    model = Pipeline(steps=[
+        ("preprocess", preprocessor),
+        (
+            "regressor",
+            TransformedTargetRegressor(
+                regressor=gb_regressor,
+                func=np.log1p,
+                inverse_func=lambda x: np.expm1(np.clip(x, a_min=None, a_max=20)),
+            ),
+        ),
+    ])
+
+    return model
+
+
+def _neg_rmsle(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    y_pred = np.maximum(y_pred, 0.0)
+    return -math.sqrt(mean_squared_log_error(y_true, y_pred))
+
+
+rmsle_scorer = make_scorer(_neg_rmsle, greater_is_better=True)
+
+
+def main() -> None:
+    raw_df = _load_dataset()
+    df = _engineer_features(raw_df)
+
+    feature_cols = [
+        'views',
+        'videos',
+        'channel_age_years',
+        'views_per_video',
+        'uploads_per_year',
+        'log_views_growth',
+    ]
+
+    df = df.dropna(subset=feature_cols + ['subs']).copy()
+
+    X = df[feature_cols]
+    y = df['subs']
+
+    model = _build_pipeline(feature_cols)
+
+    print("Running 5-fold cross-validation...")
+    cv_results = cross_validate(
+        model,
+        X,
+        y,
+        scoring={'r2': 'r2', 'rmsle': rmsle_scorer},
+        cv=5,
+        n_jobs=-1,
+        return_train_score=False,
+    )
+
+    mean_r2 = cv_results['test_r2'].mean()
+    std_r2 = cv_results['test_r2'].std()
+    mean_rmsle = -cv_results['test_rmsle'].mean()
+    std_rmsle = cv_results['test_rmsle'].std()
+
+    print(f"CV R2: {mean_r2:.3f} ± {std_r2:.3f}")
+    print(f"CV RMSLE: {mean_rmsle:.3f} ± {std_rmsle:.3f}")
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+    model.fit(X_train, y_train)
+    check_is_fitted(model)
+
+    preds = model.predict(X_test)
+    preds = np.maximum(preds, 0)
+
+    holdout_r2 = r2_score(y_test, preds)
+    holdout_rmsle = math.sqrt(mean_squared_log_error(y_test, preds))
+
+    print("Hold-out R2:", round(holdout_r2, 3))
+    print("Hold-out RMSLE:", round(holdout_rmsle, 3))
+
+    # Extract feature importances from underlying estimator if available.
+    inner_regressor = model.named_steps['regressor'].regressor_
+    if hasattr(inner_regressor, 'feature_importances_'):
+        importances = inner_regressor.feature_importances_
+        feat_imp = (
+            pd.Series(importances, index=feature_cols)
+            .sort_values(ascending=False)
+        )
+        print("\nTop feature importances (split gain):")
+        for name, val in feat_imp.items():
+            print(f"  {name:<20} {val:.3f}")
+
+    # Save hold-out predictions for inspection.
+    output = pd.DataFrame({
+        'channel_title': df.loc[X_test.index, 'channel_title'].values
+        if 'channel_title' in df.columns else X_test.index,
+        'actual_subs': y_test,
+        'predicted_subs': preds,
+    })
+    output_path = Path('predictions_refined_model.csv')
+    output.to_csv(output_path, index=False)
+    print(f"Saved hold-out predictions to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/refined_model.py
+++ b/refined_model.py
@@ -159,6 +159,25 @@ def main() -> None:
     preds = model.predict(X_test)
     preds = np.maximum(preds, 0)
 
+from pathlib import Path
+from joblib import dump
+import json
+
+Path("models").mkdir(exist_ok=True)
+Path("results").mkdir(exist_ok=True)
+
+dump(model, "models/refined_subscriber_model.joblib")
+print("Saved model to models/refined_subscriber_model.joblib")
+
+metrics = {
+    "holdout_r2": float(r2_score(y_test, preds)),
+    "holdout_rmsle": float(np.sqrt(mean_squared_log_error(y_test.clip(min=0)+1,
+                                                           preds.clip(min=0)+1)))
+}
+(Path("results") / "metrics.json").write_text(json.dumps(metrics, indent=2))
+print("Saved metrics to results/metrics.json")
+
+
     holdout_r2 = r2_score(y_test, preds)
     holdout_rmsle = math.sqrt(mean_squared_log_error(y_test, preds))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas>=1.5,<2.1
+numpy>=1.23,<2.0
+scikit-learn>=1.2,<2.0
+joblib>=1.2,<2.0
+streamlit>=1.26,<1.33


### PR DESCRIPTION
## Summary
- add `main.py` to train the refined gradient boosting model, save metrics, and persist the artifact
- introduce a Streamlit app that loads the trained model for single or batch subscriber predictions
- document the new workflow in the README and add supporting requirement and ignore files

## Testing
- python -m py_compile main.py app.py

