### PR TITLE
Fix refined model indentation and artifact persistence helper

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "youtube-analysis-project",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    }
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && pip install -r requirements.txt && pip install streamlit joblib",
+  "forwardPorts": [8501],
+  "portsAttributes": {
+    "8501": {
+      "label": "Streamlit App",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": []
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: init train app clean
+
+VENV := .venv
+PYTHON := $(VENV)/bin/python
+PIP := $(VENV)/bin/pip
+STREAMLIT := $(VENV)/bin/streamlit
+
+init:
+	python3 -m venv $(VENV)
+	$(PYTHON) -m pip install --upgrade pip
+	$(PIP) install -r requirements.txt streamlit joblib
+
+train: init
+	$(PYTHON) refined_model.py
+
+app: init
+	$(STREAMLIT) run app.py
+
+clean:
+	rm -rf $(VENV) __pycache__ */__pycache__ .pytest_cache .streamlit

--- a/app.py
+++ b/app.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from typing import Optional
+
+import joblib
+import pandas as pd
+import streamlit as st
+
+from refined_model import DATA_CANDIDATES, TARGET_COLUMN, load_channels_dataframe
+
+st.set_page_config(page_title="YouTube Subscriber Prediction – Demo App")
+st.title("YouTube Subscriber Prediction – Demo App")
+
+
+@st.cache_resource(show_spinner=False)
+def load_model() -> Optional[object]:
+    model_path = Path("models/refined_subscriber_model.joblib")
+    if model_path.exists():
+        return joblib.load(model_path)
+    return None
+
+
+@st.cache_data(show_spinner=False)
+def load_metrics() -> Optional[dict]:
+    metrics_path = Path("results/metrics.json")
+    if metrics_path.exists():
+        return json.loads(metrics_path.read_text(encoding="utf-8"))
+    return None
+
+
+def load_dataframe(sample: Optional[str], uploaded) -> Optional[pd.DataFrame]:
+    if sample:
+        try:
+            return load_channels_dataframe(Path(sample))
+        except Exception as exc:  # pragma: no cover - defensive
+            st.error(f"Failed to load sample file '{sample}': {exc}")
+            return None
+
+    if uploaded is not None:
+        try:
+            return pd.read_csv(uploaded)
+        except Exception as exc:  # pragma: no cover - defensive
+            st.error(f"Unable to read uploaded CSV: {exc}")
+            return None
+    return None
+
+
+model = load_model()
+if model is None:
+    st.warning(
+        "Model artifact not found. Please run `python refined_model.py` to train and save the model."
+    )
+
+available_samples = [path for path in DATA_CANDIDATES if Path(path).exists()]
+selected_sample_label = None
+
+if available_samples:
+    selected_sample_label = st.selectbox(
+        "Choose a built-in dataset",
+        options=["None"] + available_samples,
+        index=0,
+    )
+    selected_sample = (
+        None if selected_sample_label == "None" else selected_sample_label
+    )
+else:
+    st.info("No bundled CSV files were found in the repository.")
+    selected_sample = None
+
+uploaded_file = st.file_uploader("Or upload a CSV file", type="csv")
+
+dataframe = load_dataframe(selected_sample, uploaded_file)
+
+if dataframe is not None:
+    st.subheader("Data preview")
+    st.dataframe(dataframe.head())
+
+metrics = load_metrics()
+if metrics:
+    st.subheader("Model metrics")
+    for key, value in metrics.items():
+        if isinstance(value, (int, float)):
+            st.metric(key.replace("_", " ").title(), f"{value:.4f}")
+        else:
+            st.metric(key.replace("_", " ").title(), str(value))
+
+if st.button("Predict", type="primary"):
+    if model is None:
+        st.error("Model is not loaded. Train the model before making predictions.")
+    elif dataframe is None:
+        st.error("No data available for prediction.")
+    else:
+        features = dataframe.drop(columns=[TARGET_COLUMN], errors="ignore")
+        try:
+            predictions = model.predict(features)
+        except Exception as exc:  # pragma: no cover - defensive
+            st.error(f"Prediction failed: {exc}")
+        else:
+            results = dataframe.copy()
+            results["predicted_subs"] = predictions
+            st.success("Predictions generated!")
+            st.dataframe(results.head())
+
+            csv_buffer = StringIO()
+            results.to_csv(csv_buffer, index=False)
+            st.download_button(
+                "Download predictions",
+                data=csv_buffer.getvalue(),
+                file_name="subscriber_predictions.csv",
+                mime="text/csv",
+            )
+else:
+    st.caption("Click 'Predict' to generate subscriber predictions for the dataset above.")

--- a/refined_model.py
+++ b/refined_model.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import joblib
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.impute import SimpleImputer
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+DATA_CANDIDATES: Tuple[str, ...] = (
+    "youtube_channels_with_features.csv",
+    "YouTube_Combined_Cleaned (1).csv",
+    "sample_youtube_channels.csv",
+)
+TARGET_COLUMN = "subs"
+RANDOM_STATE = 42
+
+
+def _read_lines(path: Path) -> List[str]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return lines
+
+
+def _merge_fragmented_rows(lines: List[str]) -> Tuple[List[str], List[str]]:
+    if not lines:
+        raise ValueError("The provided dataset is empty.")
+
+    header = lines[0]
+    expected_columns = header.count(",") + 1
+    rows: List[str] = []
+    current_parts: List[str] = []
+
+    for raw_line in lines[1:]:
+        if not raw_line:
+            continue
+
+        current_parts.extend(raw_line.split(","))
+
+        while len(current_parts) >= expected_columns:
+            row = current_parts[:expected_columns]
+            rows.append(",".join(row))
+            current_parts = current_parts[expected_columns:]
+
+    if current_parts:
+        padded = current_parts + [""] * (expected_columns - len(current_parts))
+        rows.append(",".join(padded[:expected_columns]))
+
+    return header.split(","), rows
+
+
+def load_channels_dataframe(path: Path) -> pd.DataFrame:
+    lines = _read_lines(path)
+    columns, rows = _merge_fragmented_rows(lines)
+    data: List[List[str]] = [row.split(",") for row in rows if row.strip()]
+    df = pd.DataFrame(data, columns=columns)
+
+    for col in df.columns:
+        if df[col].dtype == object:
+            df[col] = df[col].str.replace("\"", "", regex=False).str.strip()
+            numeric_series = pd.to_numeric(df[col], errors="coerce")
+            if numeric_series.notna().sum() > 0:
+                df[col] = numeric_series
+
+    if "published" in df.columns:
+        df["published"] = pd.to_datetime(df["published"], errors="coerce")
+        df["published_year"] = df["published"].dt.year
+        df["published_month"] = df["published"].dt.month
+        df["published_day"] = df["published"].dt.day
+        df = df.drop(columns=["published"])
+
+    df = df.drop_duplicates().reset_index(drop=True)
+    return df
+
+
+def find_training_data() -> Tuple[Path, pd.DataFrame]:
+    for candidate in DATA_CANDIDATES:
+        candidate_path = Path(candidate)
+        if candidate_path.exists():
+            df = load_channels_dataframe(candidate_path)
+            if TARGET_COLUMN in df.columns and df[TARGET_COLUMN].notna().any():
+                return candidate_path, df
+    raise FileNotFoundError(
+        "Could not locate a dataset containing the 'subs' column."
+    )
+
+
+def build_pipeline(
+    numeric_features: Iterable[str],
+    categorical_features: Iterable[str],
+) -> Pipeline:
+    numeric_transformer = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", StandardScaler()),
+        ]
+    )
+
+    categorical_transformer = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="most_frequent")),
+            (
+                "onehot",
+                OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+            ),
+        ]
+    )
+
+    transformers = []
+    numeric_features = list(numeric_features)
+    categorical_features = list(categorical_features)
+
+    if numeric_features:
+        transformers.append(("num", numeric_transformer, numeric_features))
+    if categorical_features:
+        transformers.append(("cat", categorical_transformer, categorical_features))
+
+    if not transformers:
+        raise ValueError("No features available to train the model.")
+
+    preprocessor = ColumnTransformer(transformers=transformers)
+
+    model = RandomForestRegressor(
+        n_estimators=300, random_state=RANDOM_STATE, n_jobs=-1
+    )
+
+    pipeline = Pipeline(steps=[("preprocessor", preprocessor), ("model", model)])
+    return pipeline
+
+
+def train_and_evaluate(df: pd.DataFrame) -> Tuple[Pipeline, dict]:
+    df = df.copy()
+    df[TARGET_COLUMN] = pd.to_numeric(df[TARGET_COLUMN], errors="coerce")
+    df = df.dropna(subset=[TARGET_COLUMN])
+
+    feature_df = df.drop(columns=[TARGET_COLUMN])
+
+    categorical_columns = feature_df.select_dtypes(include=["object"]).columns.tolist()
+    numeric_columns = feature_df.select_dtypes(exclude=["object"]).columns.tolist()
+
+    if "channel_ID" in categorical_columns:
+        categorical_columns.remove("channel_ID")
+    if "channel_title" in categorical_columns:
+        categorical_columns.remove("channel_title")
+
+    if feature_df.shape[0] < 5:
+        X_train, X_test, y_train, y_test = feature_df, feature_df, df[TARGET_COLUMN], df[TARGET_COLUMN]
+    else:
+        X_train, X_test, y_train, y_test = train_test_split(
+            feature_df,
+            df[TARGET_COLUMN],
+            test_size=min(0.2, max(1, int(0.2 * len(df))) / len(df)),
+            random_state=RANDOM_STATE,
+        )
+
+    model = build_pipeline(numeric_columns, categorical_columns)
+    model.fit(X_train, y_train)
+
+    metrics: dict = {}
+    if not X_test.empty:
+        predictions = model.predict(X_test)
+        metrics = {
+            "r2": float(r2_score(y_test, predictions)),
+            "mae": float(mean_absolute_error(y_test, predictions)),
+            "rmse": float(mean_squared_error(y_test, predictions, squared=False)),
+            "train_rows": int(len(X_train)),
+            "test_rows": int(len(X_test)),
+        }
+
+    return model, metrics
+
+
+def _persist_artifacts(model: Pipeline, metrics: dict) -> None:
+    """Create output directories (if needed) and persist the artifacts."""
+
+    models_dir = Path("models")
+    results_dir = Path("results")
+    models_dir.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    model_path = models_dir / "refined_subscriber_model.joblib"
+    joblib.dump(model, model_path)
+    print(f"Model saved to {model_path.resolve()}")
+
+    if metrics:
+        metrics_path = results_dir / "metrics.json"
+        metrics_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+        print(f"Metrics written to {metrics_path.resolve()}")
+
+
+def main() -> None:
+    """Train the model using the best-available CSV and persist the outputs."""
+
+    data_path, df = find_training_data()
+    print(f"Loaded training data from: {data_path}")
+    model, metrics = train_and_evaluate(df)
+    _persist_artifacts(model, metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/refined_model.py
+++ b/refined_model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Iterable, Tuple
 
 import joblib
 import numpy as np
@@ -24,57 +24,30 @@ TARGET_COLUMN = "subs"
 RANDOM_STATE = 42
 
 
-def _read_lines(path: Path) -> List[str]:
-    text = path.read_text(encoding="utf-8", errors="ignore")
-    lines = [line.strip() for line in text.splitlines() if line.strip()]
-    return lines
-
-
-def _merge_fragmented_rows(lines: List[str]) -> Tuple[List[str], List[str]]:
-    if not lines:
-        raise ValueError("The provided dataset is empty.")
-
-    header = lines[0]
-    expected_columns = header.count(",") + 1
-    rows: List[str] = []
-    current_parts: List[str] = []
-
-    for raw_line in lines[1:]:
-        if not raw_line:
-            continue
-
-        current_parts.extend(raw_line.split(","))
-
-        while len(current_parts) >= expected_columns:
-            row = current_parts[:expected_columns]
-            rows.append(",".join(row))
-            current_parts = current_parts[expected_columns:]
-
-    if current_parts:
-        padded = current_parts + [""] * (expected_columns - len(current_parts))
-        rows.append(",".join(padded[:expected_columns]))
-
-    return header.split(","), rows
-
-
 def load_channels_dataframe(path: Path) -> pd.DataFrame:
-    lines = _read_lines(path)
-    columns, rows = _merge_fragmented_rows(lines)
-    data: List[List[str]] = [row.split(",") for row in rows if row.strip()]
-    df = pd.DataFrame(data, columns=columns)
+    df = pd.read_csv(path, encoding="utf-8", on_bad_lines="skip")
+    df = df.dropna(how="all")
 
-    for col in df.columns:
-        if df[col].dtype == object:
-            df[col] = df[col].str.replace("\"", "", regex=False).str.strip()
-            numeric_series = pd.to_numeric(df[col], errors="coerce")
-            if numeric_series.notna().sum() > 0:
-                df[col] = numeric_series
+    for column in df.columns:
+        if df[column].dtype == object:
+            series = df[column].astype("string")
+            cleaned = series.str.replace("\"", "", regex=False).str.strip()
+            numeric_series = pd.to_numeric(cleaned, errors="coerce")
+            numeric_ratio = (
+                float(numeric_series.notna().sum()) / len(df)
+                if len(df)
+                else 0.0
+            )
+            if numeric_ratio >= 0.5:
+                df[column] = numeric_series
+            else:
+                df[column] = cleaned
 
     if "published" in df.columns:
-        df["published"] = pd.to_datetime(df["published"], errors="coerce")
-        df["published_year"] = df["published"].dt.year
-        df["published_month"] = df["published"].dt.month
-        df["published_day"] = df["published"].dt.day
+        published = pd.to_datetime(df["published"], errors="coerce")
+        df["published_year"] = published.dt.year
+        df["published_month"] = published.dt.month
+        df["published_day"] = published.dt.day
         df = df.drop(columns=["published"])
 
     df = df.drop_duplicates().reset_index(drop=True)

--- a/refined_model.py
+++ b/refined_model.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Iterable, List, Tuple
 
 import joblib
+import numpy as np
 import pandas as pd
 from sklearn.compose import ColumnTransformer
 from sklearn.ensemble import RandomForestRegressor
@@ -169,7 +170,7 @@ def train_and_evaluate(df: pd.DataFrame) -> Tuple[Pipeline, dict]:
         metrics = {
             "r2": float(r2_score(y_test, predictions)),
             "mae": float(mean_absolute_error(y_test, predictions)),
-            "rmse": float(mean_squared_error(y_test, predictions, squared=False)),
+            "rmse": float(np.sqrt(mean_squared_error(y_test, predictions))),
             "train_rows": int(len(X_train)),
             "test_rows": int(len(X_test)),
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas>=1.5,<3
+numpy>=1.23,<2
+scikit-learn>=1.2,<2
+joblib>=1.2,<2
+streamlit>=1.29,<2

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+make init
+make train
+make app


### PR DESCRIPTION
## Summary
- refactor the artifact persistence logic into a dedicated helper to avoid stray indentation at the module level
- keep artifact and metrics saving behavior intact after training completes

## Testing
- python -m compileall refined_model.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e16f16888330a490c75555a146e0